### PR TITLE
ruff 0.15.18, mypy 2.1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 hide:
     - navigation
 ---
-Copyright &copy; 2023-2025, Gufo Labs.
+Copyright &copy; 2023-2026, Gufo Labs.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,8 @@ docs = [
   "mkdocstrings[python]==0.29.1",
 ]
 lint = [
-  "mypy==1.18.2",
-  "ruff==0.14.0",
+  "mypy==2.1.0",
+  "ruff==0.15.18",
   "types-PyYAML==6.0.12.3",
 ]
 test = [


### PR DESCRIPTION
Update development linting dependencies to their latest versions and refresh the copyright year.

**Key changes:**
- `ruff`: `0.14.0` → `0.15.18` (minor version bump, ~6 months of updates)
- `mypy`: `1.18.2` → `2.1.0` **(major version bump)**
- `LICENSE.md`: copyright year `2025` → `2026`

**Impact:**
Dev-only dependencies (`lint` extras). No changes to runtime code, no breaking changes for end users.
