### PR TITLE
envoy 1.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ To see unreleased changes, please see the [CHANGELOG on the master branch](https
 
 * `--migrate` and `--no-migrate` option cannot be used simultaneously.
 * Use `webbrowser` module to open browser in more portable manner.
+* envoy 1.39.
+
+### Infrastructure
+
+* mypy 2.1.0
+* ruff 0.15.18
 
 ## 0.13.0 - 2026-06-01
 

--- a/src/gufo/thor/services/envoy.py
+++ b/src/gufo/thor/services/envoy.py
@@ -100,7 +100,7 @@ class EnvoyService(BaseService):
     """envoy service."""
 
     name = "envoy"
-    compose_image = "envoyproxy/envoy:v1.36.0"
+    compose_image = "envoyproxy/envoy:v1.39.0"
     # compose_depends_condition = ComposeDependsCondition.HEALTHY
     # compose_healthcheck = {
     #     "test": ["CMD", "envoy", "healthcheck", "--ping"],

--- a/src/gufo/thor/templates/envoy/envoy.yaml
+++ b/src/gufo/thor/templates/envoy/envoy.yaml
@@ -170,7 +170,6 @@ static_resources:
       connect_timeout: 0.25s
       type: strict_dns
       lb_policy: least_request
-      http2_protocol_options: {}
       dns_lookup_family: V4_ONLY
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:


### PR DESCRIPTION
**Purpose:** Upgrade Envoy reverse proxy from v1.36 to v1.39 and remove deprecated `http2_protocol_options` configuration that is redundant in newer versions.

**Key changes:**
- Bump envoy Docker image tag from `v1.36.0` to `v1.39.0` (`src/gufo/thor/services/envoy.py`)
- Remove obsolete `http2_protocol_options: {}` from upstream cluster config in favor of existing `typed_extension_protocol_options` (`src/gufo/thor/templates/envoy/envoy.yaml`)
- Update CHANGELOG to reflect new version and infrastructure tool upgrades

**Notable implementation details:**
- The removed `http2_protocol_options` is redundant since v1.30+ when `typed_extension_protocol_options` (ALPN-based HTTP version discovery) is already configured on the same cluster level
- Envoy upgrade spans 3 minor versions (v1.37 → v1.38 → v1.39); no breaking configuration changes reported upstream
