### PR TITLE
Remove unused cli options

### DIFF
--- a/src/gufo/thor/cli.py
+++ b/src/gufo/thor/cli.py
@@ -122,21 +122,6 @@ class Cli(object):
         subparsers.add_parser("pause", help="Pause services' containers")
         # unpause
         subparsers.add_parser("unpause", help="Resume services' containers")
-        # backup
-        backup_parser = subparsers.add_parser(
-            "backup", help="Backup databases"
-        )
-        backup_parser.add_argument(
-            "list", action="store_true", help="List backups"
-        )
-        backup_parser.add_argument(
-            "postgres", action="store_true", help="Backup postgres database"
-        )
-        backup_parser.add_argument(
-            "mongo", action="store_true", help="Backup mongo database"
-        )
-        # restore
-        subparsers.add_parser("restore", help="Restore database")
         # destroy
         destroy_parser = subparsers.add_parser(
             "destroy", help="Destroy installation and free resources"


### PR DESCRIPTION
**Purpose**

Remove dead CLI subparser definitions for `backup` and `restore` commands that never had corresponding handler methods in `Cli` class.

**Key changes**

- Removed `backup` subparser with arguments (`--list`, `--postgres`, `--mongo`)
- Removed `restore` subparser definition

**Notable implementation details**

The removed subparsers would cause a confusing `AttributeError` at runtime if invoked, since `get_handler()` tries to resolve via `getattr(self, f"handle_{name}")` and neither `handle_backup`nor `handle_restore` exist. These were likely legacy stubs from early development.
